### PR TITLE
関数ポインタなどの機能を使いやすくするため9まで上げる

### DIFF
--- a/UnmanagedDllResolveHelper/UnmanagedDllResolveHelper.csproj
+++ b/UnmanagedDllResolveHelper/UnmanagedDllResolveHelper.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Important

本当に不思議なんだけど、LangVersionを9にしたら、依存していない方のライブラリテストが落ちるようになった