### PR TITLE
Support Linux

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,11 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          # NOTE: Since merged https://github.com/yamachu/UnmanagedDllResolveHelper/pull/6 , this library is not worked on Linux.
-          # due to NativeAOT with LangVersion >= 9 or switchExpression...?
-          # - os: ubuntu-latest
-          #   env_fail: SampleNativeLibrary.so
-          #   env_pass: SampleNativeLibraryWithLoader.so
+          - os: ubuntu-latest
+            env_fail: SampleNativeLibrary.so
+            env_pass: SampleNativeLibraryWithLoader.so
           - os: windows-latest
             env_fail: SampleNativeLibrary.dll
             env_pass: SampleNativeLibraryWithLoader.dll

--- a/TestResources/SampleNativeLibrary/SampleNativeLibrary.csproj
+++ b/TestResources/SampleNativeLibrary/SampleNativeLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>

--- a/TestResources/SampleNativeLibraryDependency/SampleNativeLibraryDependency.csproj
+++ b/TestResources/SampleNativeLibraryDependency/SampleNativeLibraryDependency.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>

--- a/TestResources/SampleNativeLibraryWithLoader/SampleNativeLibraryWithLoader.csproj
+++ b/TestResources/SampleNativeLibraryWithLoader/SampleNativeLibraryWithLoader.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>

--- a/UnmanagedDllResolveHelper/Platform/Linux.cs
+++ b/UnmanagedDllResolveHelper/Platform/Linux.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace UnmanagedDllResolveHelper.Platform
+{
+
+    internal class Linux
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DlInfo
+        {
+            public IntPtr dli_fname;
+            public IntPtr dli_fbase;
+            public IntPtr dli_sname;
+            public IntPtr dli_saddr;
+        }
+
+        [DllImport("libdl")]
+        private static extern int dladdr(IntPtr addr, out DlInfo info);
+
+        [UnmanagedCallersOnly(EntryPoint = "__DONT_CALL_UnmanagedDllResolveHelper_Platform_Linux__")]
+        public static void __LINUX_NATIVE_EXPORT_FUNCTION__() { }
+
+        private static unsafe IntPtr GetCurrentModuleHandle()
+        {
+            return (IntPtr)(delegate* unmanaged<void>)&__LINUX_NATIVE_EXPORT_FUNCTION__;
+        }
+
+        public static string? GetCurrentLibraryDirectory()
+        {
+            try
+            {
+                var moduleHandle = GetCurrentModuleHandle();
+                if (moduleHandle != IntPtr.Zero)
+                {
+                    var result = dladdr(moduleHandle, out DlInfo info);
+                    if (result != 0 && info.dli_fname != IntPtr.Zero)
+                    {
+                        var modulePath = Marshal.PtrToStringAnsi(info.dli_fname);
+                        if (!string.IsNullOrEmpty(modulePath))
+                        {
+                            return Directory.GetParent(modulePath)?.FullName;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+            return null;
+        }
+
+        public static string[] GetPossibleLibraryPaths(string libraryName, string basePath)
+        {
+            var paths = new List<string>
+            {
+                Path.Combine(basePath, $"{libraryName}.so"),
+            };
+            if (!libraryName.StartsWith("lib"))
+            {
+                paths.Add(Path.Combine(basePath, $"lib{libraryName}.so"));
+            }
+
+            return paths.ToArray();
+        }
+
+    }
+}

--- a/UnmanagedDllResolveHelper/UnmanagedDllResolveHelper.cs
+++ b/UnmanagedDllResolveHelper/UnmanagedDllResolveHelper.cs
@@ -41,6 +41,10 @@ namespace UnmanagedDllResolveHelper
             {
                 return Platform.Windows.GetCurrentLibraryDirectory();
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Platform.Linux.GetCurrentLibraryDirectory();
+            }
             else
             {
                 return null;
@@ -56,6 +60,10 @@ namespace UnmanagedDllResolveHelper
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return Platform.Windows.GetPossibleLibraryPaths(libraryName, basePath);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Platform.Linux.GetPossibleLibraryPaths(libraryName, basePath);
             }
             else
             {


### PR DESCRIPTION
利用側のTargetFrameworkが.net9.0じゃないとクラッシュするので注意
see: https://github.com/dotnet/runtime/issues/117726